### PR TITLE
feat: add storage presets for Cookie, WeChat, Douyin, Alipay, uni-app, React Native, and Node.js

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -228,6 +228,75 @@ await storage.ready
 
 AI コーディングツール（Cursor、Copilot、Windsurf など）を使用している場合、[`ai-rules/.cursorrules`](./ai-rules/.cursorrules) のルールをプロジェクトルートの `.cursorrules` としてコピーすると、AI アシスタントが stokado のベストプラクティスに従います。
 
+## プリセット
+
+Stokado は一般的なストレージターゲット用のプリセット `StorageLike` アダプターを提供しており、インターフェースを自分で実装することなく `createProxyStorage` を直接使用できます。
+
+### Cookie
+
+```js
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+
+const storage = createProxyStorage(cookieStorage)
+```
+
+### WeChat ミニプログラム
+
+```js
+import { createProxyStorage } from 'stokado'
+import { wechatStorage } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorage)
+```
+
+非同期バージョン：
+
+```js
+import { wechatStorageAsync } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorageAsync)
+```
+
+### Douyin ミニプログラム
+
+```js
+import { douyinStorage, douyinStorageAsync } from 'stokado/presets/douyin'
+```
+
+### Alipay ミニプログラム
+
+```js
+import { alipayStorage, alipayStorageAsync } from 'stokado/presets/alipay'
+```
+
+### uni-app
+
+```js
+import { uniStorage, uniStorageAsync } from 'stokado/presets/uni-app'
+```
+
+### React Native
+
+React Native では `AsyncStorage` インスタンスの注入が必要です：
+
+```js
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createProxyStorage } from 'stokado'
+import { createReactNativeStorage } from 'stokado/presets/react-native'
+
+const storage = createProxyStorage(createReactNativeStorage(AsyncStorage))
+```
+
+### Node.js
+
+```js
+import { createProxyStorage } from 'stokado'
+import { memoryStorage } from 'stokado/presets/node'
+
+const storage = createProxyStorage(memoryStorage)
+```
+
 ## localForage と一緒に使う
 
 `localForage` は `localStorage` と同じ API を提供しているため、`stokado` と一緒に使用できます。

--- a/README.md
+++ b/README.md
@@ -226,6 +226,75 @@ await storage.ready
 
 If you're using AI coding tools (Cursor, Copilot, Windsurf, etc.), copy the rules from [`ai-rules/.cursorrules`](./ai-rules/.cursorrules) to your project root as `.cursorrules` to help your AI assistant follow stokado best practices.
 
+## Presets
+
+Stokado provides preset `StorageLike` adapters for common storage targets, so you can use `createProxyStorage` directly without implementing the interface yourself.
+
+### Cookie
+
+```js
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+
+const storage = createProxyStorage(cookieStorage)
+```
+
+### WeChat Mini Program
+
+```js
+import { createProxyStorage } from 'stokado'
+import { wechatStorage } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorage)
+```
+
+Async version:
+
+```js
+import { wechatStorageAsync } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorageAsync)
+```
+
+### Douyin Mini Program
+
+```js
+import { douyinStorage, douyinStorageAsync } from 'stokado/presets/douyin'
+```
+
+### Alipay Mini Program
+
+```js
+import { alipayStorage, alipayStorageAsync } from 'stokado/presets/alipay'
+```
+
+### uni-app
+
+```js
+import { uniStorage, uniStorageAsync } from 'stokado/presets/uni-app'
+```
+
+### React Native
+
+React Native requires injecting the `AsyncStorage` instance:
+
+```js
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createProxyStorage } from 'stokado'
+import { createReactNativeStorage } from 'stokado/presets/react-native'
+
+const storage = createProxyStorage(createReactNativeStorage(AsyncStorage))
+```
+
+### Node.js
+
+```js
+import { createProxyStorage } from 'stokado'
+import { memoryStorage } from 'stokado/presets/node'
+
+const storage = createProxyStorage(memoryStorage)
+```
+
 ## Work with localForage
 
 `localForage` provides the same API as `localStorage`, it can be used in conjunction with `stokado`.

--- a/README.zh.md
+++ b/README.zh.md
@@ -228,6 +228,75 @@ await storage.ready
 
 如果你使用 AI 编码工具（Cursor、Copilot、Windsurf 等），可以将 [`ai-rules/.cursorrules`](./ai-rules/.cursorrules) 中的规则复制到项目根目录的 `.cursorrules` 文件中，帮助 AI 助手遵循 stokado 最佳实践。
 
+## 预设适配器
+
+Stokado 为常见的存储目标提供了预设的 `StorageLike` 适配器，无需自行实现接口即可直接使用 `createProxyStorage`。
+
+### Cookie
+
+```js
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+
+const storage = createProxyStorage(cookieStorage)
+```
+
+### 微信小程序
+
+```js
+import { createProxyStorage } from 'stokado'
+import { wechatStorage } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorage)
+```
+
+异步版本：
+
+```js
+import { wechatStorageAsync } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorageAsync)
+```
+
+### 抖音小程序
+
+```js
+import { douyinStorage, douyinStorageAsync } from 'stokado/presets/douyin'
+```
+
+### 支付宝小程序
+
+```js
+import { alipayStorage, alipayStorageAsync } from 'stokado/presets/alipay'
+```
+
+### uni-app
+
+```js
+import { uniStorage, uniStorageAsync } from 'stokado/presets/uni-app'
+```
+
+### React Native
+
+React Native 需要注入 `AsyncStorage` 实例：
+
+```js
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createProxyStorage } from 'stokado'
+import { createReactNativeStorage } from 'stokado/presets/react-native'
+
+const storage = createProxyStorage(createReactNativeStorage(AsyncStorage))
+```
+
+### Node.js
+
+```js
+import { createProxyStorage } from 'stokado'
+import { memoryStorage } from 'stokado/presets/node'
+
+const storage = createProxyStorage(memoryStorage)
+```
+
 ## Work with localForage
 
 因为 `localForage` 提供了跟 `localStorage` 一样的 API，它是类 `storage` 对象，可以跟 `stokado` 配合使用。

--- a/ai-rules/.cursorrules
+++ b/ai-rules/.cursorrules
@@ -34,6 +34,17 @@ When this project uses stokado for browser storage, follow these conventions:
 - stokado syncs across tabs via BroadcastChannel by default for localStorage
 - Disable with `createProxyStorage(localStorage, { broadcast: false })` if not needed
 
+## Presets
+- Use preset adapters from `stokado/presets/*` instead of implementing `StorageLike` yourself
+- Cookie: `import { cookieStorage } from 'stokado/presets/cookie'`
+- WeChat Mini Program: `import { wechatStorage } from 'stokado/presets/wechat'` (sync) or `import { wechatStorageAsync } from 'stokado/presets/wechat'` (async)
+- Douyin Mini Program: `import { douyinStorage } from 'stokado/presets/douyin'` (sync) or `import { douyinStorageAsync } from 'stokado/presets/douyin'` (async)
+- Alipay Mini Program: `import { alipayStorage } from 'stokado/presets/alipay'` (sync) or `import { alipayStorageAsync } from 'stokado/presets/alipay'` (async)
+- uni-app: `import { uniStorage } from 'stokado/presets/uni-app'` (sync) or `import { uniStorageAsync } from 'stokado/presets/uni-app'` (async)
+- React Native: `import { createReactNativeStorage } from 'stokado/presets/react-native'` — requires injecting AsyncStorage: `createReactNativeStorage(AsyncStorage)`
+- Node.js: `import { memoryStorage } from 'stokado/presets/node'` — in-memory Map-based storage
+- Each preset is a separate sub-path export for tree-shaking
+
 ## Quota Alert
 - Use `createProxyStorage(storage, { quota: 5 * MB })` to set a storage size limit in bytes
 - Use `KB` and `MB` constants from stokado for readable quota values

--- a/docs/superpowers/plans/2026-05-29-storage-presets.md
+++ b/docs/superpowers/plans/2026-05-29-storage-presets.md
@@ -1,0 +1,1265 @@
+# Storage Presets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add preset StorageLike adapters for Cookie, WeChat, Douyin, Alipay, uni-app, React Native, and Node.js, enabling direct use with `createProxyStorage`.
+
+**Architecture:** Generic mini-program adapter shared by WeChat/Douyin/uni-app, separate Alipay adapter (different API signature), independent Cookie/React Native/Node.js adapters. Each preset exported via sub-path for tree-shaking.
+
+**Tech Stack:** TypeScript, Rollup, Vitest
+
+---
+
+## File Structure
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `src/presets/node.ts` | In-memory Map-based SyncStorageLike |
+| Create | `src/presets/cookie.ts` | Cookie-based SyncStorageLike |
+| Create | `src/presets/mini-program.ts` | Generic mini-program factory + types |
+| Create | `src/presets/wechat.ts` | WeChat convenience wrapper |
+| Create | `src/presets/douyin.ts` | Douyin convenience wrapper |
+| Create | `src/presets/uni-app.ts` | uni-app convenience wrapper |
+| Create | `src/presets/alipay.ts` | Alipay adapter + types |
+| Create | `src/presets/react-native.ts` | React Native factory + types |
+| Modify | `package.json` | Add sub-path exports |
+| Modify | `rollup.config.js` | Add preset entry points |
+| Create | `tests/unit/presets/node.test.ts` | Node memory storage tests |
+| Create | `tests/unit/presets/cookie.test.ts` | Cookie adapter tests |
+| Create | `tests/unit/presets/mini-program.test.ts` | Generic mini-program tests |
+| Create | `tests/unit/presets/alipay.test.ts` | Alipay adapter tests |
+| Create | `tests/unit/presets/react-native.test.ts` | React Native adapter tests |
+
+---
+
+### Task 1: Node.js Memory Storage
+
+**Files:**
+- Create: `src/presets/node.ts`
+- Create: `tests/unit/presets/node.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest'
+import type { SyncStorageLike } from '@/types'
+
+describe('memoryStorage', () => {
+  it('should implement SyncStorageLike', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    const storage: SyncStorageLike = memoryStorage
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('foo', 'bar')
+    expect(memoryStorage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    expect(memoryStorage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('foo', 'bar')
+    memoryStorage.removeItem('foo')
+    expect(memoryStorage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('a', '1')
+    memoryStorage.setItem('b', '2')
+    memoryStorage.clear()
+    expect(memoryStorage.length).toBe(0)
+  })
+
+  it('should return key by index', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    memoryStorage.setItem('first', '1')
+    memoryStorage.setItem('second', '2')
+    expect(memoryStorage.key(0)).toBe('first')
+    expect(memoryStorage.key(1)).toBe('second')
+    expect(memoryStorage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    memoryStorage.setItem('a', '1')
+    memoryStorage.setItem('b', '2')
+    expect(memoryStorage.length).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/presets/node.test.ts`
+Expected: FAIL — module `@/presets/node` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { SyncStorageLike } from '@/types'
+
+const map = new Map<string, string>()
+
+export const memoryStorage: SyncStorageLike = {
+  getItem(key: string): string | null {
+    return map.get(key) ?? null
+  },
+  setItem(key: string, value: any): void {
+    map.set(key, value)
+  },
+  removeItem(key: string): void {
+    map.delete(key)
+  },
+  clear(): void {
+    map.clear()
+  },
+  key(index: number): string | null {
+    return [...map.keys()][index] ?? null
+  },
+  get length(): number {
+    return map.size
+  },
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/presets/node.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/presets/node.ts tests/unit/presets/node.test.ts
+git commit -m "feat: add memoryStorage preset for Node.js"
+```
+
+---
+
+### Task 2: Cookie Adapter
+
+**Files:**
+- Create: `src/presets/cookie.ts`
+- Create: `tests/unit/presets/cookie.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SyncStorageLike } from '@/types'
+
+let cookieStore: Record<string, string> = {}
+
+vi.stubGlobal('document', {
+  get cookie() {
+    return Object.entries(cookieStore)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('; ')
+  },
+  set cookie(val: string) {
+    const [pair] = val.split(';')
+    const eqIndex = pair.indexOf('=')
+    if (eqIndex === -1) return
+    const key = decodeURIComponent(pair.slice(0, eqIndex).trim())
+    const value = decodeURIComponent(pair.slice(eqIndex + 1).trim())
+    if (value === '' && val.includes('expires=')) {
+      delete cookieStore[key]
+    } else {
+      cookieStore[key] = value
+    }
+  },
+})
+
+describe('cookieStorage', () => {
+  beforeEach(() => {
+    cookieStore = {}
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    const storage: SyncStorageLike = cookieStorage
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('foo', 'bar')
+    expect(cookieStorage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    expect(cookieStorage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('foo', 'bar')
+    cookieStorage.removeItem('foo')
+    expect(cookieStorage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('a', '1')
+    cookieStorage.setItem('b', '2')
+    cookieStorage.clear()
+    expect(cookieStorage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('first', '1')
+    cookieStorage.setItem('second', '2')
+    const keys = [cookieStorage.key(0), cookieStorage.key(1)]
+    expect(keys).toContain('first')
+    expect(keys).toContain('second')
+    expect(cookieStorage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('a', '1')
+    cookieStorage.setItem('b', '2')
+    expect(cookieStorage.length).toBe(2)
+  })
+
+  it('should handle special characters', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('key with spaces', 'value=with=equals')
+    expect(cookieStorage.getItem('key with spaces')).toBe('value=with=equals')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/presets/cookie.test.ts`
+Expected: FAIL — module `@/presets/cookie` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { SyncStorageLike } from '@/types'
+
+function parseCookies(): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!document.cookie) return map
+  document.cookie.split(';').forEach((cookie) => {
+    const eqIndex = cookie.indexOf('=')
+    if (eqIndex === -1) return
+    const key = decodeURIComponent(cookie.slice(0, eqIndex).trim())
+    const value = decodeURIComponent(cookie.slice(eqIndex + 1).trim())
+    map.set(key, value)
+  })
+  return map
+}
+
+export const cookieStorage: SyncStorageLike = {
+  getItem(key: string): string | null {
+    return parseCookies().get(key) ?? null
+  },
+  setItem(key: string, value: any): void {
+    document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+  },
+  removeItem(key: string): void {
+    document.cookie = `${encodeURIComponent(key)}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  },
+  clear(): void {
+    const keys = [...parseCookies().keys()]
+    for (const key of keys) {
+      document.cookie = `${encodeURIComponent(key)}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    }
+  },
+  key(index: number): string | null {
+    return [...parseCookies().keys()][index] ?? null
+  },
+  get length(): number {
+    return parseCookies().size
+  },
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/presets/cookie.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/presets/cookie.ts tests/unit/presets/cookie.test.ts
+git commit -m "feat: add cookieStorage preset"
+```
+
+---
+
+### Task 3: Generic Mini-Program Adapter
+
+**Files:**
+- Create: `src/presets/mini-program.ts`
+- Create: `tests/unit/presets/mini-program.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { SyncStorageLike, AsyncStorageLike } from '@/types'
+
+function createMockMiniProgramAPI() {
+  const store = new Map<string, any>()
+  return {
+    getStorageSync(key: string) {
+      return store.get(key) ?? ''
+    },
+    setStorageSync(key: string, data: any) {
+      store.set(key, data)
+    },
+    removeStorageSync(key: string) {
+      store.delete(key)
+    },
+    clearStorageSync() {
+      store.clear()
+    },
+    getStorageInfoSync() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+    async getStorage(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data ?? '' }
+    },
+    async setStorage(options: { key: string; data: any }) {
+      store.set(options.key, options.data)
+    },
+    async removeStorage(options: { key: string }) {
+      store.delete(options.key)
+    },
+    async clearStorage() {
+      store.clear()
+    },
+    async getStorageInfo() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+  }
+}
+
+describe('createMiniProgramStorage', () => {
+  let api: ReturnType<typeof createMockMiniProgramAPI>
+
+  beforeEach(() => {
+    api = createMockMiniProgramAPI()
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage: SyncStorageLike = createMiniProgramStorage(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('foo', 'bar')
+    expect(storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    expect(storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('foo', 'bar')
+    storage.removeItem('foo')
+    expect(storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    storage.clear()
+    expect(storage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('first', '1')
+    storage.setItem('second', '2')
+    expect(storage.key(0)).toBe('first')
+    expect(storage.key(1)).toBe('second')
+    expect(storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    expect(storage.length).toBe(2)
+  })
+})
+
+describe('createMiniProgramStorageAsync', () => {
+  let api: ReturnType<typeof createMockMiniProgramAPI>
+
+  beforeEach(() => {
+    api = createMockMiniProgramAPI()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage: AsyncStorageLike = createMiniProgramStorageAsync(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('first', '1')
+    await storage.setItem('second', '2')
+    expect(await storage.key(0)).toBe('first')
+    expect(await storage.key(1)).toBe('second')
+    expect(await storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    expect(await storage.length()).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/presets/mini-program.test.ts`
+Expected: FAIL — module `@/presets/mini-program` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+
+export interface MiniProgramSyncAPI {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+export interface MiniProgramAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+export function createMiniProgramStorage(api: MiniProgramSyncAPI): SyncStorageLike {
+  return {
+    getItem(key: string): string | null {
+      const value = api.getStorageSync(key)
+      return value === '' ? null : value
+    },
+    setItem(key: string, value: any): void {
+      api.setStorageSync(key, value)
+    },
+    removeItem(key: string): void {
+      api.removeStorageSync(key)
+    },
+    clear(): void {
+      api.clearStorageSync()
+    },
+    key(index: number): string | null {
+      return api.getStorageInfoSync().keys[index] ?? null
+    },
+    get length(): number {
+      return api.getStorageInfoSync().keys.length
+    },
+  }
+}
+
+export function createMiniProgramStorageAsync(api: MiniProgramAsyncAPI): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      const { data } = await api.getStorage({ key })
+      return data === '' ? null : data
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await api.setStorage({ key, data: value })
+    },
+    async removeItem(key: string): Promise<void> {
+      await api.removeStorage({ key })
+    },
+    async clear(): Promise<void> {
+      await api.clearStorage()
+    },
+    async key(index: number): Promise<string | null> {
+      const { keys } = await api.getStorageInfo()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const { keys } = await api.getStorageInfo()
+      return keys.length
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/presets/mini-program.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/presets/mini-program.ts tests/unit/presets/mini-program.test.ts
+git commit -m "feat: add generic mini-program storage adapter"
+```
+
+---
+
+### Task 4: WeChat Preset Wrapper
+
+**Files:**
+- Create: `src/presets/wechat.ts`
+
+- [ ] **Step 1: Write implementation**
+
+```ts
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
+
+declare const wx: {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+export const wechatStorage: SyncStorageLike = createMiniProgramStorage(wx)
+export const wechatStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(wx)
+export { createMiniProgramStorage, createMiniProgramStorageAsync }
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no type errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presets/wechat.ts
+git commit -m "feat: add WeChat mini-program preset"
+```
+
+---
+
+### Task 5: Douyin Preset Wrapper
+
+**Files:**
+- Create: `src/presets/douyin.ts`
+
+- [ ] **Step 1: Write implementation**
+
+```ts
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
+
+declare const tt: {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+export const douyinStorage: SyncStorageLike = createMiniProgramStorage(tt)
+export const douyinStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(tt)
+export { createMiniProgramStorage, createMiniProgramStorageAsync }
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presets/douyin.ts
+git commit -m "feat: add Douyin mini-program preset"
+```
+
+---
+
+### Task 6: uni-app Preset Wrapper
+
+**Files:**
+- Create: `src/presets/uni-app.ts`
+
+- [ ] **Step 1: Write implementation**
+
+```ts
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
+
+declare const uni: {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+export const uniStorage: SyncStorageLike = createMiniProgramStorage(uni)
+export const uniStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(uni)
+export { createMiniProgramStorage, createMiniProgramStorageAsync }
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/presets/uni-app.ts
+git commit -m "feat: add uni-app preset"
+```
+
+---
+
+### Task 7: Alipay Adapter
+
+**Files:**
+- Create: `src/presets/alipay.ts`
+- Create: `tests/unit/presets/alipay.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { SyncStorageLike, AsyncStorageLike } from '@/types'
+
+function createMockAlipayAPI() {
+  const store = new Map<string, any>()
+  return {
+    getStorageSync(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data !== undefined ? data : null }
+    },
+    setStorageSync(options: { key: string; data: any }) {
+      store.set(options.key, options.data)
+    },
+    removeStorageSync(options: { key: string }) {
+      store.delete(options.key)
+    },
+    clearStorageSync() {
+      store.clear()
+    },
+    getStorageInfoSync() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+    async getStorage(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data !== undefined ? data : null }
+    },
+    async setStorage(options: { key: string; data: any }) {
+      store.set(options.key, options.data)
+    },
+    async removeStorage(options: { key: string }) {
+      store.delete(options.key)
+    },
+    async clearStorage() {
+      store.clear()
+    },
+    async getStorageInfo() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+  }
+}
+
+describe('alipayStorage', () => {
+  let api: ReturnType<typeof createMockAlipayAPI>
+
+  beforeEach(() => {
+    api = createMockAlipayAPI()
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage: SyncStorageLike = createAlipayStorage(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('foo', 'bar')
+    expect(storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    expect(storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('foo', 'bar')
+    storage.removeItem('foo')
+    expect(storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    storage.clear()
+    expect(storage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('first', '1')
+    storage.setItem('second', '2')
+    expect(storage.key(0)).toBe('first')
+    expect(storage.key(1)).toBe('second')
+    expect(storage.key(2)).toBeNull()
+  })
+})
+
+describe('alipayStorageAsync', () => {
+  let api: ReturnType<typeof createMockAlipayAPI>
+
+  beforeEach(() => {
+    api = createMockAlipayAPI()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage: AsyncStorageLike = createAlipayStorageAsync(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/presets/alipay.test.ts`
+Expected: FAIL — module `@/presets/alipay` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+
+export interface AlipaySyncAPI {
+  getStorageSync(options: { key: string }): { data: any }
+  setStorageSync(options: { key: string; data: any }): void
+  removeStorageSync(options: { key: string }): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+export interface AlipayAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+declare const my: AlipaySyncAPI & AlipayAsyncAPI
+
+export function createAlipayStorage(api: AlipaySyncAPI): SyncStorageLike {
+  return {
+    getItem(key: string): string | null {
+      const { data } = api.getStorageSync({ key })
+      return data ?? null
+    },
+    setItem(key: string, value: any): void {
+      api.setStorageSync({ key, data: value })
+    },
+    removeItem(key: string): void {
+      api.removeStorageSync({ key })
+    },
+    clear(): void {
+      api.clearStorageSync()
+    },
+    key(index: number): string | null {
+      return api.getStorageInfoSync().keys[index] ?? null
+    },
+    get length(): number {
+      return api.getStorageInfoSync().keys.length
+    },
+  }
+}
+
+export function createAlipayStorageAsync(api: AlipayAsyncAPI): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      const { data } = await api.getStorage({ key })
+      return data ?? null
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await api.setStorage({ key, data: value })
+    },
+    async removeItem(key: string): Promise<void> {
+      await api.removeStorage({ key })
+    },
+    async clear(): Promise<void> {
+      await api.clearStorage()
+    },
+    async key(index: number): Promise<string | null> {
+      const { keys } = await api.getStorageInfo()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const { keys } = await api.getStorageInfo()
+      return keys.length
+    },
+  }
+}
+
+export const alipayStorage: SyncStorageLike = createAlipayStorage(my)
+export const alipayStorageAsync: AsyncStorageLike = createAlipayStorageAsync(my)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/presets/alipay.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/presets/alipay.ts tests/unit/presets/alipay.test.ts
+git commit -m "feat: add Alipay mini-program preset"
+```
+
+---
+
+### Task 8: React Native Adapter
+
+**Files:**
+- Create: `src/presets/react-native.ts`
+- Create: `tests/unit/presets/react-native.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { beforeEach, describe, expect, it } from 'vitest'
+import type { AsyncStorageLike } from '@/types'
+
+function createMockAsyncStorage() {
+  const store = new Map<string, string>()
+  return {
+    async getItem(key: string): Promise<string | null> {
+      return store.get(key) ?? null
+    },
+    async setItem(key: string, value: string): Promise<void> {
+      store.set(key, value)
+    },
+    async removeItem(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async clear(): Promise<void> {
+      store.clear()
+    },
+    async getAllKeys(): Promise<string[]> {
+      return [...store.keys()]
+    },
+  }
+}
+
+describe('createReactNativeStorage', () => {
+  let asyncStorage: ReturnType<typeof createMockAsyncStorage>
+
+  beforeEach(() => {
+    asyncStorage = createMockAsyncStorage()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage: AsyncStorageLike = createReactNativeStorage(asyncStorage)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('first', '1')
+    await storage.setItem('second', '2')
+    expect(await storage.key(0)).toBe('first')
+    expect(await storage.key(1)).toBe('second')
+    expect(await storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    expect(await storage.length()).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/presets/react-native.test.ts`
+Expected: FAIL — module `@/presets/react-native` not found
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { AsyncStorageLike } from '@/types'
+
+export interface ReactNativeAsyncStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+  clear(): Promise<void>
+  getAllKeys(): Promise<string[]>
+}
+
+export function createReactNativeStorage(asyncStorage: ReactNativeAsyncStorage): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      return asyncStorage.getItem(key)
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await asyncStorage.setItem(key, value)
+    },
+    async removeItem(key: string): Promise<void> {
+      await asyncStorage.removeItem(key)
+    },
+    async clear(): Promise<void> {
+      await asyncStorage.clear()
+    },
+    async key(index: number): Promise<string | null> {
+      const keys = await asyncStorage.getAllKeys()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const keys = await asyncStorage.getAllKeys()
+      return keys.length
+    },
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/presets/react-native.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/presets/react-native.ts tests/unit/presets/react-native.test.ts
+git commit -m "feat: add React Native storage preset"
+```
+
+---
+
+### Task 9: Build Configuration
+
+**Files:**
+- Modify: `package.json`
+- Modify: `rollup.config.js`
+
+- [ ] **Step 1: Update package.json exports**
+
+Add sub-path exports for each preset in `package.json`. The existing `"."` entry stays unchanged. Add the following entries after it:
+
+```json
+"./presets/cookie": {
+  "types": "./dist/presets/cookie.d.ts",
+  "import": "./dist/presets/cookie.mjs",
+  "require": "./dist/presets/cookie.cjs"
+},
+"./presets/wechat": {
+  "types": "./dist/presets/wechat.d.ts",
+  "import": "./dist/presets/wechat.mjs",
+  "require": "./dist/presets/wechat.cjs"
+},
+"./presets/douyin": {
+  "types": "./dist/presets/douyin.d.ts",
+  "import": "./dist/presets/douyin.mjs",
+  "require": "./dist/presets/douyin.cjs"
+},
+"./presets/alipay": {
+  "types": "./dist/presets/alipay.d.ts",
+  "import": "./dist/presets/alipay.mjs",
+  "require": "./dist/presets/alipay.cjs"
+},
+"./presets/uni-app": {
+  "types": "./dist/presets/uni-app.d.ts",
+  "import": "./dist/presets/uni-app.mjs",
+  "require": "./dist/presets/uni-app.cjs"
+},
+"./presets/react-native": {
+  "types": "./dist/presets/react-native.d.ts",
+  "import": "./dist/presets/react-native.mjs",
+  "require": "./dist/presets/react-native.cjs"
+},
+"./presets/node": {
+  "types": "./dist/presets/node.d.ts",
+  "import": "./dist/presets/node.mjs",
+  "require": "./dist/presets/node.cjs"
+}
+```
+
+- [ ] **Step 2: Update rollup.config.js**
+
+Add preset entry points to the rollup config. Each preset needs its own input and generates `.mjs`, `.cjs`, and `.d.ts` outputs. Insert the following logic after the existing `configs.push(...)` for the main entry:
+
+```js
+const presetEntries = [
+  'cookie',
+  'wechat',
+  'douyin',
+  'alipay',
+  'uni-app',
+  'react-native',
+  'node',
+]
+
+if (process.env.BUILD === 'prod') {
+  for (const preset of presetEntries) {
+    const presetInput = path.resolve(__dirname, `src/presets/${preset}.ts`)
+    configs.push({
+      input: presetInput,
+      output: [
+        {
+          file: `dist/presets/${preset}.mjs`,
+          format: 'es',
+        },
+        {
+          file: `dist/presets/${preset}.cjs`,
+          format: 'cjs',
+        },
+      ],
+      plugins: [pluginEsbuild, typescript({ declaration: false }), pluginAlias, nodeResolve()],
+    }, {
+      input: presetInput,
+      output: {
+        file: `dist/presets/${preset}.d.ts`,
+        format: 'es',
+      },
+      plugins: [dts(), pluginAlias],
+    })
+  }
+}
+```
+
+- [ ] **Step 3: Run build to verify**
+
+Run: `npm run build`
+Expected: Build succeeds with all preset files generated in `dist/presets/`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json rollup.config.js
+git commit -m "feat: add preset sub-path exports and build config"
+```
+
+---
+
+### Task 10: Final Verification
+
+- [ ] **Step 1: Run all unit tests**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: No type errors
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No lint errors
+
+- [ ] **Step 4: Run full build**
+
+Run: `npm run build`
+Expected: Build succeeds with all outputs in `dist/`
+
+- [ ] **Step 5: Verify dist output structure**
+
+Run: `ls -la dist/presets/`
+Expected: All 7 preset directories with `.mjs`, `.cjs`, `.d.ts` files

--- a/docs/superpowers/specs/2026-05-29-storage-presets-design.md
+++ b/docs/superpowers/specs/2026-05-29-storage-presets-design.md
@@ -1,0 +1,241 @@
+# Storage Presets Design
+
+## Overview
+
+Add preset `StorageLike` adapters for common storage targets (Cookie, WeChat Mini Program, Douyin Mini Program, Alipay Mini Program, uni-app, React Native, Node.js), enabling users to pass them directly into `createProxyStorage`.
+
+## Architecture
+
+### Approach: Generic Mini-Program Adapter + Platform Convenience Wrappers
+
+WeChat, Douyin, and uni-app share identical storage API signatures. A shared `createMiniProgramStorage` / `createMiniProgramStorageAsync` eliminates duplication. Alipay has a different API signature and gets its own implementation. Cookie, React Native, and Node.js each have unique implementations.
+
+## File Structure
+
+```
+src/presets/
+  cookie.ts           → cookieStorage: SyncStorageLike
+  mini-program.ts     → createMiniProgramStorage / createMiniProgramStorageAsync + types
+  wechat.ts           → wechatStorage / wechatStorageAsync
+  douyin.ts           → douyinStorage / douyinStorageAsync
+  alipay.ts           → alipayStorage / alipayStorageAsync + types
+  uni-app.ts          → uniStorage / uniStorageAsync
+  react-native.ts     → createReactNativeStorage + types
+  node.ts             → memoryStorage: SyncStorageLike
+```
+
+## Exports
+
+### Sub-path Exports (package.json)
+
+Each preset is a separate sub-path export for tree-shaking:
+
+```json
+{
+  "exports": {
+    ".": { "types": "./dist/stokado.d.ts", "import": "./dist/stokado.mjs", "require": "./dist/stokado.cjs" },
+    "./presets/cookie": { "types": "./dist/presets/cookie.d.ts", "import": "./dist/presets/cookie.mjs", "require": "./dist/presets/cookie.cjs" },
+    "./presets/wechat": { "types": "./dist/presets/wechat.d.ts", "import": "./dist/presets/wechat.mjs", "require": "./dist/presets/wechat.cjs" },
+    "./presets/douyin": { "types": "./dist/presets/douyin.d.ts", "import": "./dist/presets/douyin.mjs", "require": "./dist/presets/douyin.cjs" },
+    "./presets/alipay": { "types": "./dist/presets/alipay.d.ts", "import": "./dist/presets/alipay.mjs", "require": "./dist/presets/alipay.cjs" },
+    "./presets/uni-app": { "types": "./dist/presets/uni-app.d.ts", "import": "./dist/presets/uni-app.mjs", "require": "./dist/presets/uni-app.cjs" },
+    "./presets/react-native": { "types": "./dist/presets/react-native.d.ts", "import": "./dist/presets/react-native.mjs", "require": "./dist/presets/react-native.cjs" },
+    "./presets/node": { "types": "./dist/presets/node.d.ts", "import": "./dist/presets/node.mjs", "require": "./dist/presets/node.cjs" }
+  }
+}
+```
+
+### Export Names
+
+| Sub-path | Export Name | Type | Notes |
+|----------|-------------|------|-------|
+| `stokado/presets/cookie` | `cookieStorage` | `SyncStorageLike` | Based on `document.cookie` |
+| `stokado/presets/wechat` | `wechatStorage` | `SyncStorageLike` | Based on `wx` global |
+| `stokado/presets/wechat` | `wechatStorageAsync` | `AsyncStorageLike` | Based on `wx` global |
+| `stokado/presets/douyin` | `douyinStorage` | `SyncStorageLike` | Based on `tt` global |
+| `stokado/presets/douyin` | `douyinStorageAsync` | `AsyncStorageLike` | Based on `tt` global |
+| `stokado/presets/alipay` | `alipayStorage` | `SyncStorageLike` | Based on `my` global |
+| `stokado/presets/alipay` | `alipayStorageAsync` | `AsyncStorageLike` | Based on `my` global |
+| `stokado/presets/uni-app` | `uniStorage` | `SyncStorageLike` | Based on `uni` global |
+| `stokado/presets/uni-app` | `uniStorageAsync` | `AsyncStorageLike` | Based on `uni` global |
+| `stokado/presets/react-native` | `createReactNativeStorage` | Factory function | Requires AsyncStorage injection |
+| `stokado/presets/node` | `memoryStorage` | `SyncStorageLike` | In-memory Map-based |
+
+The generic factory functions are also exported from their respective files for advanced use:
+- `createMiniProgramStorage(api)` and `createMiniProgramStorageAsync(api)` from `stokado/presets/mini-program` (if we decide to expose this sub-path)
+
+## Type Definitions
+
+### Mini-Program API Types (mini-program.ts)
+
+```ts
+interface MiniProgramSyncAPI {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+interface MiniProgramAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+```
+
+### Alipay API Types (alipay.ts)
+
+```ts
+interface AlipaySyncAPI {
+  getStorageSync(options: { key: string }): { data: any }
+  setStorageSync(options: { key: string; data: any }): void
+  removeStorageSync(options: { key: string }): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+interface AlipayAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+```
+
+### React Native Types (react-native.ts)
+
+```ts
+interface ReactNativeAsyncStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+  clear(): Promise<void>
+  getAllKeys(): Promise<string[]>
+}
+```
+
+## Implementation Details
+
+### Cookie Adapter (cookie.ts)
+
+Cookie API is string-based (`document.cookie`), requiring parsing:
+
+- `getItem(key)`: Parse `document.cookie` with regex, `decodeURIComponent` on value
+- `setItem(key, value)`: Set `document.cookie` with `encodeURIComponent`
+- `removeItem(key)`: Set cookie with `expires=Thu, 01 Jan 1970 00:00:00 GMT`
+- `clear()`: Iterate all cookie keys, remove each
+- `key(index)`: Parse all keys, return key at index or `null`
+- `length` (getter): Count of cookie entries
+
+### Generic Mini-Program Adapter (mini-program.ts)
+
+WeChat, Douyin, and uni-app share this implementation:
+
+**Sync (`createMiniProgramStorage(api)`):**
+- `getItem(key)`: `api.getStorageSync(key)` — convert empty string to `null`
+- `setItem(key, value)`: `api.setStorageSync(key, value)`
+- `removeItem(key)`: `api.removeStorageSync(key)`
+- `clear()`: `api.clearStorageSync()`
+- `key(index)`: `api.getStorageInfoSync().keys[index] ?? null`
+- `length` (getter): `api.getStorageInfoSync().keys.length`
+
+**Async (`createMiniProgramStorageAsync(api)`):**
+- `getItem(key)`: `api.getStorage({ key })` → extract `.data`
+- `setItem(key, value)`: `api.setStorage({ key, data: value })`
+- `removeItem(key)`: `api.removeStorage({ key })`
+- `clear()`: `api.clearStorage()`
+- `key(index)`: `api.getStorageInfo().keys[index] ?? null`
+- `length()`: `api.getStorageInfo().keys.length`
+
+### Alipay Adapter (alipay.ts)
+
+Alipay uses object parameters and different return formats:
+
+**Sync (`alipayStorage`):**
+- `getItem(key)`: `my.getStorageSync({ key }).data` — unwrap `{data}` object
+- `setItem(key, value)`: `my.setStorageSync({ key, data: value })` — object params
+- `removeItem(key)`: `my.removeStorageSync({ key })` — object params
+- `clear()`: `my.clearStorageSync()`
+- `key(index)`: `my.getStorageInfoSync().keys[index] ?? null`
+- `length` (getter): `my.getStorageInfoSync().keys.length`
+
+**Async (`alipayStorageAsync`):**
+- `getItem(key)`: `my.getStorage({ key })` → extract `.data`
+- `setItem(key, value)`: `my.setStorage({ key, data: value })`
+- `removeItem(key)`: `my.removeStorage({ key })`
+- `clear()`: `my.clearStorage()`
+- `key(index)`: `my.getStorageInfo().keys[index] ?? null`
+- `length()`: `my.getStorageInfo().keys.length`
+
+### React Native Adapter (react-native.ts)
+
+Factory function requiring AsyncStorage injection:
+
+- `getItem(key)`: `asyncStorage.getItem(key)` — already returns `Promise<string | null>`
+- `setItem(key, value)`: `asyncStorage.setItem(key, value)`
+- `removeItem(key)`: `asyncStorage.removeItem(key)`
+- `clear()`: `asyncStorage.clear()`
+- `key(index)`: `asyncStorage.getAllKeys()[index] ?? null`
+- `length()`: `asyncStorage.getAllKeys().length`
+
+### Node.js Memory Storage (node.ts)
+
+Simple Map-based in-memory storage:
+
+- `getItem(key)`: `map.get(key) ?? null`
+- `setItem(key, value)`: `map.set(key, value)`
+- `removeItem(key)`: `map.delete(key)`
+- `clear()`: `map.clear()`
+- `key(index)`: `[...map.keys()][index] ?? null`
+- `length` (getter): `map.size`
+
+## Edge Cases
+
+| Scenario | Handling |
+|----------|----------|
+| WeChat `getStorageSync` returns empty string for missing key | Convert to `null` to match `getItem` contract |
+| Cookie values with special characters | `encodeURIComponent` / `decodeURIComponent` |
+| Alipay `getStorageSync` returns `{data}` wrapper | Unwrap `.data` property |
+| `key()` out-of-bounds access | Return `null` |
+| `length` calls `getStorageInfoSync` on every access | Acceptable for mini-programs (small storage, low overhead) |
+
+## Build Configuration
+
+### Rollup Changes
+
+Add preset entry points to `rollup.config.js`. Each preset generates `.mjs`, `.cjs`, `.d.ts` outputs independently.
+
+### tsconfig Changes
+
+Include `src/presets/**/*.ts` in the compilation.
+
+## Usage Examples
+
+```ts
+// Cookie
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+const storage = createProxyStorage(cookieStorage)
+
+// WeChat Mini Program (sync)
+import { createProxyStorage } from 'stokado'
+import { wechatStorage } from 'stokado/presets/wechat'
+const storage = createProxyStorage(wechatStorage)
+
+// WeChat Mini Program (async)
+import { wechatStorageAsync } from 'stokado/presets/wechat'
+const storage = createProxyStorage(wechatStorageAsync)
+
+// React Native
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createReactNativeStorage } from 'stokado/presets/react-native'
+const storage = createProxyStorage(createReactNativeStorage(AsyncStorage))
+
+// Node.js
+import { memoryStorage } from 'stokado/presets/node'
+const storage = createProxyStorage(memoryStorage)
+```

--- a/docs/superpowers/specs/2026-05-29-storage-presets-design.md
+++ b/docs/superpowers/specs/2026-05-29-storage-presets-design.md
@@ -61,8 +61,9 @@ Each preset is a separate sub-path export for tree-shaking:
 | `stokado/presets/react-native` | `createReactNativeStorage` | Factory function | Requires AsyncStorage injection |
 | `stokado/presets/node` | `memoryStorage` | `SyncStorageLike` | In-memory Map-based |
 
-The generic factory functions are also exported from their respective files for advanced use:
-- `createMiniProgramStorage(api)` and `createMiniProgramStorageAsync(api)` from `stokado/presets/mini-program` (if we decide to expose this sub-path)
+The generic factory functions are also re-exported from each platform file for advanced use (e.g., when the global object is not available at import time or for testing):
+- `createMiniProgramStorage(api)` and `createMiniProgramStorageAsync(api)` are re-exported from `stokado/presets/wechat`, `stokado/presets/douyin`, and `stokado/presets/uni-app`
+- `mini-program.ts` is an internal module, not exposed as a separate sub-path export
 
 ## Type Definitions
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -312,6 +312,125 @@ The size calculation is based on the UTF-8 byte size of the encoded envelope (ke
 - Direct writes to the underlying storage from the same tab (bypassing stokado) are not tracked and may cause actual usage to exceed the quota without triggering an alert.
 - Cross-tab writes are tracked through the `storage` event when broadcast is enabled, but there may be a brief delay.
 
+## Presets
+
+Stokado provides preset `StorageLike` adapters for common storage targets, so you can use `createProxyStorage` directly without implementing the interface yourself. Each preset is a separate sub-path export for tree-shaking.
+
+### Cookie
+
+```js
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+
+const storage = createProxyStorage(cookieStorage)
+```
+
+### WeChat Mini Program
+
+```js
+import { createProxyStorage } from 'stokado'
+import { wechatStorage } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorage)
+```
+
+Async version:
+
+```js
+import { wechatStorageAsync } from 'stokado/presets/wechat'
+
+const storage = createProxyStorage(wechatStorageAsync)
+```
+
+### Douyin Mini Program
+
+```js
+import { douyinStorage } from 'stokado/presets/douyin'
+import { douyinStorageAsync } from 'stokado/presets/douyin'
+```
+
+### Alipay Mini Program
+
+```js
+import { alipayStorage } from 'stokado/presets/alipay'
+import { alipayStorageAsync } from 'stokado/presets/alipay'
+```
+
+### uni-app
+
+```js
+import { uniStorage } from 'stokado/presets/uni-app'
+import { uniStorageAsync } from 'stokado/presets/uni-app'
+```
+
+### React Native
+
+React Native requires injecting the `AsyncStorage` instance:
+
+```js
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createProxyStorage } from 'stokado'
+import { createReactNativeStorage } from 'stokado/presets/react-native'
+
+const storage = createProxyStorage(createReactNativeStorage(AsyncStorage))
+```
+
+### Node.js
+
+```js
+import { createProxyStorage } from 'stokado'
+import { memoryStorage } from 'stokado/presets/node'
+
+const storage = createProxyStorage(memoryStorage)
+```
+
+### Preset Type Definitions
+
+```typescript
+// Mini-program adapters (WeChat, Douyin, uni-app)
+interface MiniProgramSyncAPI {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+interface MiniProgramAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+// Alipay adapters
+interface AlipaySyncAPI {
+  getStorageSync(options: { key: string }): { data: any }
+  setStorageSync(options: { key: string; data: any }): void
+  removeStorageSync(options: { key: string }): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+}
+
+interface AlipayAsyncAPI {
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+// React Native adapter
+interface ReactNativeAsyncStorage {
+  getItem(key: string): Promise<string | null>
+  setItem(key: string, value: string): Promise<void>
+  removeItem(key: string): Promise<void>
+  clear(): Promise<void>
+  getAllKeys(): Promise<string[]>
+}
+```
+
 ## Async Storage (localForage, IndexedDB)
 
 stokado automatically detects async storage backends and returns Promises.

--- a/llms.txt
+++ b/llms.txt
@@ -81,6 +81,24 @@ stokado is the only browser storage library that combines proxy syntax sugar, ty
 - `storage.getUsage()` — returns `{ current, limit }` for quota tracking
 - `storage.ready` — `Promise<void>`, resolves when size tracker init completes
 
+## Presets
+
+Stokado provides preset `StorageLike` adapters for common storage targets. Each is a separate sub-path export for tree-shaking.
+
+- `cookieStorage` from `stokado/presets/cookie` — Cookie-based SyncStorageLike
+- `wechatStorage` / `wechatStorageAsync` from `stokado/presets/wechat` — WeChat Mini Program
+- `douyinStorage` / `douyinStorageAsync` from `stokado/presets/douyin` — Douyin Mini Program
+- `alipayStorage` / `alipayStorageAsync` from `stokado/presets/alipay` — Alipay Mini Program
+- `uniStorage` / `uniStorageAsync` from `stokado/presets/uni-app` — uni-app
+- `createReactNativeStorage(AsyncStorage)` from `stokado/presets/react-native` — React Native (factory, inject AsyncStorage)
+- `memoryStorage` from `stokado/presets/node` — Node.js in-memory Map-based SyncStorageLike
+
+```js
+import { createProxyStorage } from 'stokado'
+import { cookieStorage } from 'stokado/presets/cookie'
+const storage = createProxyStorage(cookieStorage)
+```
+
 ## When to use stokado
 
 - You need localStorage values to preserve their JavaScript type (number, boolean, Date, RegExp, etc.)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,41 @@
       "types": "./dist/stokado.d.ts",
       "import": "./dist/stokado.mjs",
       "require": "./dist/stokado.cjs"
+    },
+    "./presets/cookie": {
+      "types": "./dist/presets/cookie.d.ts",
+      "import": "./dist/presets/cookie.mjs",
+      "require": "./dist/presets/cookie.cjs"
+    },
+    "./presets/wechat": {
+      "types": "./dist/presets/wechat.d.ts",
+      "import": "./dist/presets/wechat.mjs",
+      "require": "./dist/presets/wechat.cjs"
+    },
+    "./presets/douyin": {
+      "types": "./dist/presets/douyin.d.ts",
+      "import": "./dist/presets/douyin.mjs",
+      "require": "./dist/presets/douyin.cjs"
+    },
+    "./presets/alipay": {
+      "types": "./dist/presets/alipay.d.ts",
+      "import": "./dist/presets/alipay.mjs",
+      "require": "./dist/presets/alipay.cjs"
+    },
+    "./presets/uni-app": {
+      "types": "./dist/presets/uni-app.d.ts",
+      "import": "./dist/presets/uni-app.mjs",
+      "require": "./dist/presets/uni-app.cjs"
+    },
+    "./presets/react-native": {
+      "types": "./dist/presets/react-native.d.ts",
+      "import": "./dist/presets/react-native.mjs",
+      "require": "./dist/presets/react-native.cjs"
+    },
+    "./presets/node": {
+      "types": "./dist/presets/node.d.ts",
+      "import": "./dist/presets/node.mjs",
+      "require": "./dist/presets/node.cjs"
     }
   },
   "main": "dist/stokado.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stokado",
   "type": "module",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Feature-rich proxy wrapper for browser storage with serialization, reactivity, expiration, and one-time values. Works with localStorage, sessionStorage, and async storages like localForage.",
   "author": "KID-joker",
   "license": "MIT",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,4 +78,41 @@ configs.push({
   plugins,
 })
 
+const presetEntries = [
+  'cookie',
+  'wechat',
+  'douyin',
+  'alipay',
+  'uni-app',
+  'react-native',
+  'node',
+]
+
+if (process.env.BUILD === 'prod') {
+  for (const preset of presetEntries) {
+    const presetInput = path.resolve(__dirname, `src/presets/${preset}.ts`)
+    configs.push({
+      input: presetInput,
+      output: [
+        {
+          file: `dist/presets/${preset}.mjs`,
+          format: 'es',
+        },
+        {
+          file: `dist/presets/${preset}.cjs`,
+          format: 'cjs',
+        },
+      ],
+      plugins: [pluginEsbuild, typescript({ declaration: false }), pluginAlias, nodeResolve()],
+    }, {
+      input: presetInput,
+      output: {
+        file: `dist/presets/${preset}.d.ts`,
+        format: 'es',
+      },
+      plugins: [dts(), pluginAlias],
+    })
+  }
+}
+
 export default configs

--- a/src/presets/alipay.ts
+++ b/src/presets/alipay.ts
@@ -1,0 +1,80 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+
+export interface AlipaySyncAPI {
+  getStorageSync: (options: { key: string }) => { data: any }
+  setStorageSync: (options: { key: string, data: any }) => void
+  removeStorageSync: (options: { key: string }) => void
+  clearStorageSync: () => void
+  getStorageInfoSync: () => { keys: string[], currentSize: number, limitSize: number }
+}
+
+export interface AlipayAsyncAPI {
+  getStorage: (options: { key: string }) => Promise<{ data: any }>
+  setStorage: (options: { key: string, data: any }) => Promise<void>
+  removeStorage: (options: { key: string }) => Promise<void>
+  clearStorage: () => Promise<void>
+  getStorageInfo: () => Promise<{ keys: string[], currentSize: number, limitSize: number }>
+}
+
+declare const my: AlipaySyncAPI & AlipayAsyncAPI
+
+export function createAlipayStorage(api: AlipaySyncAPI): SyncStorageLike {
+  return {
+    getItem(key: string): string | null {
+      const { data } = api.getStorageSync({ key })
+      return data ?? null
+    },
+    setItem(key: string, value: any): void {
+      api.setStorageSync({ key, data: value })
+    },
+    removeItem(key: string): void {
+      api.removeStorageSync({ key })
+    },
+    clear(): void {
+      api.clearStorageSync()
+    },
+    key(index: number): string | null {
+      return api.getStorageInfoSync().keys[index] ?? null
+    },
+    get length(): number {
+      return api.getStorageInfoSync().keys.length
+    },
+  }
+}
+
+export function createAlipayStorageAsync(api: AlipayAsyncAPI): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      const { data } = await api.getStorage({ key })
+      return data ?? null
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await api.setStorage({ key, data: value })
+    },
+    async removeItem(key: string): Promise<void> {
+      await api.removeStorage({ key })
+    },
+    async clear(): Promise<void> {
+      await api.clearStorage()
+    },
+    async key(index: number): Promise<string | null> {
+      const { keys } = await api.getStorageInfo()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const { keys } = await api.getStorageInfo()
+      return keys.length
+    },
+  }
+}
+
+export const alipayStorage: SyncStorageLike = new Proxy({} as SyncStorageLike, {
+  get(_, prop) {
+    return createAlipayStorage(my)[prop as keyof SyncStorageLike]
+  },
+})
+export const alipayStorageAsync: AsyncStorageLike = new Proxy({} as AsyncStorageLike, {
+  get(_, prop) {
+    return createAlipayStorageAsync(my)[prop as keyof AsyncStorageLike]
+  },
+})

--- a/src/presets/cookie.ts
+++ b/src/presets/cookie.ts
@@ -1,0 +1,40 @@
+import type { SyncStorageLike } from '@/types'
+
+function parseCookies(): Map<string, string> {
+  const map = new Map<string, string>()
+  if (!document.cookie)
+    return map
+  document.cookie.split(';').forEach((cookie) => {
+    const eqIndex = cookie.indexOf('=')
+    if (eqIndex === -1)
+      return
+    const key = decodeURIComponent(cookie.slice(0, eqIndex).trim())
+    const value = decodeURIComponent(cookie.slice(eqIndex + 1).trim())
+    map.set(key, value)
+  })
+  return map
+}
+
+export const cookieStorage: SyncStorageLike = {
+  getItem(key: string): string | null {
+    return parseCookies().get(key) ?? null
+  },
+  setItem(key: string, value: any): void {
+    document.cookie = `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+  },
+  removeItem(key: string): void {
+    document.cookie = `${encodeURIComponent(key)}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+  },
+  clear(): void {
+    const keys = [...parseCookies().keys()]
+    for (const key of keys) {
+      document.cookie = `${encodeURIComponent(key)}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`
+    }
+  },
+  key(index: number): string | null {
+    return [...parseCookies().keys()][index] ?? null
+  },
+  get length(): number {
+    return parseCookies().size
+  },
+}

--- a/src/presets/douyin.ts
+++ b/src/presets/douyin.ts
@@ -1,0 +1,19 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
+
+declare const tt: {
+  getStorageSync: (key: string) => any
+  setStorageSync: (key: string, data: any) => void
+  removeStorageSync: (key: string) => void
+  clearStorageSync: () => void
+  getStorageInfoSync: () => { keys: string[], currentSize: number, limitSize: number }
+  getStorage: (options: { key: string }) => Promise<{ data: any }>
+  setStorage: (options: { key: string, data: any }) => Promise<void>
+  removeStorage: (options: { key: string }) => Promise<void>
+  clearStorage: () => Promise<void>
+  getStorageInfo: () => Promise<{ keys: string[], currentSize: number, limitSize: number }>
+}
+
+export const douyinStorage: SyncStorageLike = createMiniProgramStorage(tt)
+export const douyinStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(tt)
+export { createMiniProgramStorage, createMiniProgramStorageAsync }

--- a/src/presets/mini-program.ts
+++ b/src/presets/mini-program.ts
@@ -1,0 +1,67 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+
+export interface MiniProgramSyncAPI {
+  getStorageSync: (key: string) => any
+  setStorageSync: (key: string, data: any) => void
+  removeStorageSync: (key: string) => void
+  clearStorageSync: () => void
+  getStorageInfoSync: () => { keys: string[], currentSize: number, limitSize: number }
+}
+
+export interface MiniProgramAsyncAPI {
+  getStorage: (options: { key: string }) => Promise<{ data: any }>
+  setStorage: (options: { key: string, data: any }) => Promise<void>
+  removeStorage: (options: { key: string }) => Promise<void>
+  clearStorage: () => Promise<void>
+  getStorageInfo: () => Promise<{ keys: string[], currentSize: number, limitSize: number }>
+}
+
+export function createMiniProgramStorage(api: MiniProgramSyncAPI): SyncStorageLike {
+  return {
+    getItem(key: string): string | null {
+      const value = api.getStorageSync(key)
+      return value === '' ? null : value
+    },
+    setItem(key: string, value: any): void {
+      api.setStorageSync(key, value)
+    },
+    removeItem(key: string): void {
+      api.removeStorageSync(key)
+    },
+    clear(): void {
+      api.clearStorageSync()
+    },
+    key(index: number): string | null {
+      return api.getStorageInfoSync().keys[index] ?? null
+    },
+    get length(): number {
+      return api.getStorageInfoSync().keys.length
+    },
+  }
+}
+
+export function createMiniProgramStorageAsync(api: MiniProgramAsyncAPI): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      const { data } = await api.getStorage({ key })
+      return data === '' ? null : data
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await api.setStorage({ key, data: value })
+    },
+    async removeItem(key: string): Promise<void> {
+      await api.removeStorage({ key })
+    },
+    async clear(): Promise<void> {
+      await api.clearStorage()
+    },
+    async key(index: number): Promise<string | null> {
+      const { keys } = await api.getStorageInfo()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const { keys } = await api.getStorageInfo()
+      return keys.length
+    },
+  }
+}

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -1,0 +1,24 @@
+import type { SyncStorageLike } from '@/types'
+
+const map = new Map<string, string>()
+
+export const memoryStorage: SyncStorageLike = {
+  getItem(key: string): string | null {
+    return map.get(key) ?? null
+  },
+  setItem(key: string, value: any): void {
+    map.set(key, value)
+  },
+  removeItem(key: string): void {
+    map.delete(key)
+  },
+  clear(): void {
+    map.clear()
+  },
+  key(index: number): string | null {
+    return [...map.keys()][index] ?? null
+  },
+  get length(): number {
+    return map.size
+  },
+}

--- a/src/presets/react-native.ts
+++ b/src/presets/react-native.ts
@@ -1,0 +1,34 @@
+import type { AsyncStorageLike } from '@/types'
+
+export interface ReactNativeAsyncStorage {
+  getItem: (key: string) => Promise<string | null>
+  setItem: (key: string, value: string) => Promise<void>
+  removeItem: (key: string) => Promise<void>
+  clear: () => Promise<void>
+  getAllKeys: () => Promise<string[]>
+}
+
+export function createReactNativeStorage(asyncStorage: ReactNativeAsyncStorage): AsyncStorageLike {
+  return {
+    async getItem(key: string): Promise<string | null> {
+      return asyncStorage.getItem(key)
+    },
+    async setItem(key: string, value: any): Promise<void> {
+      await asyncStorage.setItem(key, value)
+    },
+    async removeItem(key: string): Promise<void> {
+      await asyncStorage.removeItem(key)
+    },
+    async clear(): Promise<void> {
+      await asyncStorage.clear()
+    },
+    async key(index: number): Promise<string | null> {
+      const keys = await asyncStorage.getAllKeys()
+      return keys[index] ?? null
+    },
+    async length(): Promise<number> {
+      const keys = await asyncStorage.getAllKeys()
+      return keys.length
+    },
+  }
+}

--- a/src/presets/uni-app.ts
+++ b/src/presets/uni-app.ts
@@ -1,7 +1,7 @@
 import type { AsyncStorageLike, SyncStorageLike } from '@/types'
 import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
 
-declare const wx: {
+declare const uni: {
   getStorageSync: (key: string) => any
   setStorageSync: (key: string, data: any) => void
   removeStorageSync: (key: string) => void
@@ -14,6 +14,6 @@ declare const wx: {
   getStorageInfo: () => Promise<{ keys: string[], currentSize: number, limitSize: number }>
 }
 
-export const wechatStorage: SyncStorageLike = createMiniProgramStorage(wx)
-export const wechatStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(wx)
+export const uniStorage: SyncStorageLike = createMiniProgramStorage(uni)
+export const uniStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(uni)
 export { createMiniProgramStorage, createMiniProgramStorageAsync }

--- a/src/presets/wechat.ts
+++ b/src/presets/wechat.ts
@@ -1,0 +1,19 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { createMiniProgramStorage, createMiniProgramStorageAsync } from '@/presets/mini-program'
+
+declare const wx: {
+  getStorageSync(key: string): any
+  setStorageSync(key: string, data: any): void
+  removeStorageSync(key: string): void
+  clearStorageSync(): void
+  getStorageInfoSync(): { keys: string[]; currentSize: number; limitSize: number }
+  getStorage(options: { key: string }): Promise<{ data: any }>
+  setStorage(options: { key: string; data: any }): Promise<void>
+  removeStorage(options: { key: string }): Promise<void>
+  clearStorage(): Promise<void>
+  getStorageInfo(): Promise<{ keys: string[]; currentSize: number; limitSize: number }>
+}
+
+export const wechatStorage: SyncStorageLike = createMiniProgramStorage(wx)
+export const wechatStorageAsync: AsyncStorageLike = createMiniProgramStorageAsync(wx)
+export { createMiniProgramStorage, createMiniProgramStorageAsync }

--- a/tests/unit/presets/alipay.test.ts
+++ b/tests/unit/presets/alipay.test.ts
@@ -1,0 +1,148 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+function createMockAlipayAPI() {
+  const store = new Map<string, any>()
+  return {
+    getStorageSync(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data !== undefined ? data : null }
+    },
+    setStorageSync(options: { key: string, data: any }) {
+      store.set(options.key, options.data)
+    },
+    removeStorageSync(options: { key: string }) {
+      store.delete(options.key)
+    },
+    clearStorageSync() {
+      store.clear()
+    },
+    getStorageInfoSync() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+    async getStorage(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data !== undefined ? data : null }
+    },
+    async setStorage(options: { key: string, data: any }) {
+      store.set(options.key, options.data)
+    },
+    async removeStorage(options: { key: string }) {
+      store.delete(options.key)
+    },
+    async clearStorage() {
+      store.clear()
+    },
+    async getStorageInfo() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+  }
+}
+
+describe('createAlipayStorage', () => {
+  let api: ReturnType<typeof createMockAlipayAPI>
+
+  beforeEach(() => {
+    api = createMockAlipayAPI()
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage: SyncStorageLike = createAlipayStorage(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('foo', 'bar')
+    expect(storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    expect(storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('foo', 'bar')
+    storage.removeItem('foo')
+    expect(storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    storage.clear()
+    expect(storage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createAlipayStorage } = await import('@/presets/alipay')
+    const storage = createAlipayStorage(api)
+    storage.setItem('first', '1')
+    storage.setItem('second', '2')
+    expect(storage.key(0)).toBe('first')
+    expect(storage.key(1)).toBe('second')
+    expect(storage.key(2)).toBeNull()
+  })
+})
+
+describe('createAlipayStorageAsync', () => {
+  let api: ReturnType<typeof createMockAlipayAPI>
+
+  beforeEach(() => {
+    api = createMockAlipayAPI()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage: AsyncStorageLike = createAlipayStorageAsync(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createAlipayStorageAsync } = await import('@/presets/alipay')
+    const storage = createAlipayStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+})

--- a/tests/unit/presets/cookie.test.ts
+++ b/tests/unit/presets/cookie.test.ts
@@ -1,0 +1,92 @@
+import type { SyncStorageLike } from '@/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+let cookieStore: Record<string, string> = {}
+
+vi.stubGlobal('document', {
+  get cookie() {
+    return Object.entries(cookieStore)
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .join('; ')
+  },
+  set cookie(val: string) {
+    const [pair] = val.split(';')
+    const eqIndex = pair.indexOf('=')
+    if (eqIndex === -1)
+      return
+    const key = decodeURIComponent(pair.slice(0, eqIndex).trim())
+    const value = decodeURIComponent(pair.slice(eqIndex + 1).trim())
+    if (value === '' && val.includes('expires=')) {
+      delete cookieStore[key]
+    }
+    else {
+      cookieStore[key] = value
+    }
+  },
+})
+
+describe('cookieStorage', () => {
+  beforeEach(() => {
+    cookieStore = {}
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    const storage: SyncStorageLike = cookieStorage
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('foo', 'bar')
+    expect(cookieStorage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    expect(cookieStorage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('foo', 'bar')
+    cookieStorage.removeItem('foo')
+    expect(cookieStorage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('a', '1')
+    cookieStorage.setItem('b', '2')
+    cookieStorage.clear()
+    expect(cookieStorage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('first', '1')
+    cookieStorage.setItem('second', '2')
+    const keys = [cookieStorage.key(0), cookieStorage.key(1)]
+    expect(keys).toContain('first')
+    expect(keys).toContain('second')
+    expect(cookieStorage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('a', '1')
+    cookieStorage.setItem('b', '2')
+    expect(cookieStorage.length).toBe(2)
+  })
+
+  it('should handle special characters', async () => {
+    const { cookieStorage } = await import('@/presets/cookie')
+    cookieStorage.setItem('key with spaces', 'value=with=equals')
+    expect(cookieStorage.getItem('key with spaces')).toBe('value=with=equals')
+  })
+})

--- a/tests/unit/presets/mini-program.test.ts
+++ b/tests/unit/presets/mini-program.test.ts
@@ -1,0 +1,173 @@
+import type { AsyncStorageLike, SyncStorageLike } from '@/types'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+function createMockMiniProgramAPI() {
+  const store = new Map<string, any>()
+  return {
+    getStorageSync(key: string) {
+      return store.get(key) ?? ''
+    },
+    setStorageSync(key: string, data: any) {
+      store.set(key, data)
+    },
+    removeStorageSync(key: string) {
+      store.delete(key)
+    },
+    clearStorageSync() {
+      store.clear()
+    },
+    getStorageInfoSync() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+    async getStorage(options: { key: string }) {
+      const data = store.get(options.key)
+      return { data: data ?? '' }
+    },
+    async setStorage(options: { key: string, data: any }) {
+      store.set(options.key, options.data)
+    },
+    async removeStorage(options: { key: string }) {
+      store.delete(options.key)
+    },
+    async clearStorage() {
+      store.clear()
+    },
+    async getStorageInfo() {
+      return { keys: [...store.keys()], currentSize: 0, limitSize: 0 }
+    },
+  }
+}
+
+describe('createMiniProgramStorage', () => {
+  let api: ReturnType<typeof createMockMiniProgramAPI>
+
+  beforeEach(() => {
+    api = createMockMiniProgramAPI()
+  })
+
+  it('should implement SyncStorageLike', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage: SyncStorageLike = createMiniProgramStorage(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('foo', 'bar')
+    expect(storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    expect(storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('foo', 'bar')
+    storage.removeItem('foo')
+    expect(storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    storage.clear()
+    expect(storage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('first', '1')
+    storage.setItem('second', '2')
+    expect(storage.key(0)).toBe('first')
+    expect(storage.key(1)).toBe('second')
+    expect(storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createMiniProgramStorage } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorage(api)
+    storage.setItem('a', '1')
+    storage.setItem('b', '2')
+    expect(storage.length).toBe(2)
+  })
+})
+
+describe('createMiniProgramStorageAsync', () => {
+  let api: ReturnType<typeof createMockMiniProgramAPI>
+
+  beforeEach(() => {
+    api = createMockMiniProgramAPI()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage: AsyncStorageLike = createMiniProgramStorageAsync(api)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('first', '1')
+    await storage.setItem('second', '2')
+    expect(await storage.key(0)).toBe('first')
+    expect(await storage.key(1)).toBe('second')
+    expect(await storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createMiniProgramStorageAsync } = await import('@/presets/mini-program')
+    const storage = createMiniProgramStorageAsync(api)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    expect(await storage.length()).toBe(2)
+  })
+})

--- a/tests/unit/presets/node.test.ts
+++ b/tests/unit/presets/node.test.ts
@@ -1,0 +1,60 @@
+import type { SyncStorageLike } from '@/types'
+import { describe, expect, it } from 'vitest'
+
+describe('memoryStorage', () => {
+  it('should implement SyncStorageLike', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    const storage: SyncStorageLike = memoryStorage
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('number')
+  })
+
+  it('should set and get items', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('foo', 'bar')
+    expect(memoryStorage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    expect(memoryStorage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('foo', 'bar')
+    memoryStorage.removeItem('foo')
+    expect(memoryStorage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.setItem('a', '1')
+    memoryStorage.setItem('b', '2')
+    memoryStorage.clear()
+    expect(memoryStorage.length).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    memoryStorage.setItem('first', '1')
+    memoryStorage.setItem('second', '2')
+    expect(memoryStorage.key(0)).toBe('first')
+    expect(memoryStorage.key(1)).toBe('second')
+    expect(memoryStorage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { memoryStorage } = await import('@/presets/node')
+    memoryStorage.clear()
+    memoryStorage.setItem('a', '1')
+    memoryStorage.setItem('b', '2')
+    expect(memoryStorage.length).toBe(2)
+  })
+})

--- a/tests/unit/presets/react-native.test.ts
+++ b/tests/unit/presets/react-native.test.ts
@@ -1,0 +1,90 @@
+import type { AsyncStorageLike } from '@/types'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+function createMockAsyncStorage() {
+  const store = new Map<string, string>()
+  return {
+    async getItem(key: string): Promise<string | null> {
+      return store.get(key) ?? null
+    },
+    async setItem(key: string, value: string): Promise<void> {
+      store.set(key, value)
+    },
+    async removeItem(key: string): Promise<void> {
+      store.delete(key)
+    },
+    async clear(): Promise<void> {
+      store.clear()
+    },
+    async getAllKeys(): Promise<string[]> {
+      return [...store.keys()]
+    },
+  }
+}
+
+describe('createReactNativeStorage', () => {
+  let asyncStorage: ReturnType<typeof createMockAsyncStorage>
+
+  beforeEach(() => {
+    asyncStorage = createMockAsyncStorage()
+  })
+
+  it('should implement AsyncStorageLike', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage: AsyncStorageLike = createReactNativeStorage(asyncStorage)
+    expect(storage.getItem).toBeTypeOf('function')
+    expect(storage.setItem).toBeTypeOf('function')
+    expect(storage.removeItem).toBeTypeOf('function')
+    expect(storage.clear).toBeTypeOf('function')
+    expect(storage.key).toBeTypeOf('function')
+    expect(storage.length).toBeTypeOf('function')
+  })
+
+  it('should set and get items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('foo', 'bar')
+    expect(await storage.getItem('foo')).toBe('bar')
+  })
+
+  it('should return null for missing keys', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    expect(await storage.getItem('nonexistent')).toBeNull()
+  })
+
+  it('should remove items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('foo', 'bar')
+    await storage.removeItem('foo')
+    expect(await storage.getItem('foo')).toBeNull()
+  })
+
+  it('should clear all items', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    await storage.clear()
+    expect(await storage.length()).toBe(0)
+  })
+
+  it('should return key by index', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('first', '1')
+    await storage.setItem('second', '2')
+    expect(await storage.key(0)).toBe('first')
+    expect(await storage.key(1)).toBe('second')
+    expect(await storage.key(2)).toBeNull()
+  })
+
+  it('should report correct length', async () => {
+    const { createReactNativeStorage } = await import('@/presets/react-native')
+    const storage = createReactNativeStorage(asyncStorage)
+    await storage.setItem('a', '1')
+    await storage.setItem('b', '2')
+    expect(await storage.length()).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary

Add preset `StorageLike` adapters for 7 common storage targets, enabling direct use with `createProxyStorage` without implementing the interface yourself.

## Presets

| Preset | Import | Type |
|--------|--------|------|
| Cookie | `stokado/presets/cookie` → `cookieStorage` | SyncStorageLike |
| WeChat Mini Program | `stokado/presets/wechat` → `wechatStorage` / `wechatStorageAsync` | Sync + Async |
| Douyin Mini Program | `stokado/presets/douyin` → `douyinStorage` / `douyinStorageAsync` | Sync + Async |
| Alipay Mini Program | `stokado/presets/alipay` → `alipayStorage` / `alipayStorageAsync` | Sync + Async |
| uni-app | `stokado/presets/uni-app` → `uniStorage` / `uniStorageAsync` | Sync + Async |
| React Native | `stokado/presets/react-native` → `createReactNativeStorage(AsyncStorage)` | AsyncStorageLike (factory) |
| Node.js | `stokado/presets/node` → `memoryStorage` | SyncStorageLike |

## Design

- **Generic mini-program adapter** — WeChat, Douyin, and uni-app share identical storage API signatures, so a shared `createMiniProgramStorage` / `createMiniProgramStorageAsync` eliminates duplication
- **Separate Alipay adapter** — Alipay uses object parameters (`my.setStorageSync({key, data})`) and `{data}` return wrappers, requiring a distinct implementation
- **Sub-path exports** — Each preset is a separate sub-path export (`stokado/presets/cookie`, etc.) for tree-shaking
- **Factory pattern for React Native** — AsyncStorage must be injected by the user since it's not a global

## Usage

```js
import { createProxyStorage } from 'stokado'
import { cookieStorage } from 'stokado/presets/cookie'

const storage = createProxyStorage(cookieStorage)
storage.token = 'abc'
```